### PR TITLE
Phase 1: Line styling, fill rules, and blend modes

### DIFF
--- a/examples/demos/line-styles.ts
+++ b/examples/demos/line-styles.ts
@@ -1,0 +1,171 @@
+// Copyright (c) 2026 François Rouaix
+
+// Line Styles & Blend Modes Demo — showcases Phase 1 Canvas features
+import { group, rectangle, text, circle, line, arc, path, layer, ellipse } from 'vitrine';
+
+export const demo = {
+  id: 'line-styles',
+  name: 'Line Styles & Blend Modes',
+  description: 'Dashed lines, line caps/joins, fill rules, and blend modes',
+
+  init: () => {
+    return { time: 0 };
+  },
+
+  update: (state: { time: number }, dt: number) => {
+    state.time += dt;
+  },
+
+  render: (state: { time: number }) => {
+    const dashOffset = (state.time * 40) % 40;
+
+    return group({ x: 0, y: 0 }, [
+      rectangle({ dx: 800, dy: 600, fill: '#f8f9fa' }),
+
+      // Section 1: Line cap styles
+      text({ x: 60, y: 30, text: 'Line Caps', fontSize: 16, fill: '#333', baseline: 'top' as const }),
+      // butt (default)
+      text({ x: 20, y: 60, text: 'butt', fontSize: 12, fill: '#666', baseline: 'top' as const }),
+      line({ x1: 80, y1: 68, x2: 240, y2: 68, stroke: '#4dabf7', strokeWidth: 8, lineCap: 'butt' }),
+      // round
+      text({ x: 20, y: 85, text: 'round', fontSize: 12, fill: '#666', baseline: 'top' as const }),
+      line({ x1: 80, y1: 93, x2: 240, y2: 93, stroke: '#51cf66', strokeWidth: 8, lineCap: 'round' }),
+      // square
+      text({ x: 20, y: 110, text: 'square', fontSize: 12, fill: '#666', baseline: 'top' as const }),
+      line({ x1: 80, y1: 118, x2: 240, y2: 118, stroke: '#ff6b6b', strokeWidth: 8, lineCap: 'square' }),
+
+      // Section 2: Line join styles (triangles)
+      text({ x: 310, y: 30, text: 'Line Joins', fontSize: 16, fill: '#333', baseline: 'top' as const }),
+      // miter
+      text({ x: 300, y: 60, text: 'miter', fontSize: 12, fill: '#666', baseline: 'top' as const }),
+      path({ pathData: 'M 360 60 L 400 110 L 440 60', stroke: '#4dabf7', strokeWidth: 4, lineJoin: 'miter' }),
+      // round
+      text({ x: 450, y: 60, text: 'round', fontSize: 12, fill: '#666', baseline: 'top' as const }),
+      path({ pathData: 'M 510 60 L 550 110 L 590 60', stroke: '#51cf66', strokeWidth: 4, lineJoin: 'round' }),
+      // bevel
+      text({ x: 600, y: 60, text: 'bevel', fontSize: 12, fill: '#666', baseline: 'top' as const }),
+      path({ pathData: 'M 660 60 L 700 110 L 740 60', stroke: '#ff6b6b', strokeWidth: 4, lineJoin: 'bevel' }),
+
+      // Section 3: Dashed lines
+      text({ x: 60, y: 155, text: 'Dash Patterns', fontSize: 16, fill: '#333', baseline: 'top' as const }),
+      // simple dash
+      text({ x: 20, y: 185, text: '[10, 5]', fontSize: 12, fill: '#666', baseline: 'top' as const }),
+      line({ x1: 100, y1: 193, x2: 380, y2: 193, stroke: '#4dabf7', strokeWidth: 3, lineDash: [10, 5] }),
+      // dot-dash
+      text({ x: 20, y: 210, text: '[15, 5, 3, 5]', fontSize: 12, fill: '#666', baseline: 'top' as const }),
+      line({ x1: 100, y1: 218, x2: 380, y2: 218, stroke: '#51cf66', strokeWidth: 3, lineDash: [15, 5, 3, 5] }),
+      // animated dash
+      text({ x: 20, y: 235, text: 'animated', fontSize: 12, fill: '#666', baseline: 'top' as const }),
+      line({ x1: 100, y1: 243, x2: 380, y2: 243, stroke: '#ff6b6b', strokeWidth: 3, lineDash: [20, 10], lineDashOffset: dashOffset }),
+
+      // Dashed shapes
+      text({ x: 420, y: 155, text: 'Dashed Shapes', fontSize: 16, fill: '#333', baseline: 'top' as const }),
+      rectangle({ x: 420, y: 185, dx: 100, dy: 60, stroke: '#4dabf7', strokeWidth: 2, lineDash: [8, 4], cornerRadius: 8 }),
+      circle({ x: 590, y: 215, radius: 30, stroke: '#51cf66', strokeWidth: 2, lineDash: [6, 4] }),
+      ellipse({ x: 700, y: 215, radiusX: 45, radiusY: 25, stroke: '#ff6b6b', strokeWidth: 2, lineDash: [10, 5] }),
+
+      // Section 4: Fill rule (evenodd vs nonzero)
+      text({ x: 60, y: 280, text: 'Fill Rule', fontSize: 16, fill: '#333', baseline: 'top' as const }),
+      // Star with nonzero (default) — fills the entire interior
+      text({ x: 50, y: 305, text: 'nonzero', fontSize: 12, fill: '#666', baseline: 'top' as const }),
+      path({
+        pathData: starPath(120, 370, 50, 20),
+        fill: '#4dabf7',
+        stroke: '#1971c2',
+        strokeWidth: 1,
+        fillRule: 'nonzero'
+      }),
+      // Star with evenodd — creates a hole in the center
+      text({ x: 220, y: 305, text: 'evenodd', fontSize: 12, fill: '#666', baseline: 'top' as const }),
+      path({
+        pathData: starPath(290, 370, 50, 20),
+        fill: '#51cf66',
+        stroke: '#2f9e44',
+        strokeWidth: 1,
+        fillRule: 'evenodd'
+      }),
+
+      // Section 5: Blend modes
+      text({ x: 450, y: 280, text: 'Blend Modes', fontSize: 16, fill: '#333', baseline: 'top' as const }),
+      // Base rectangles
+      renderBlendDemo(450, 310, 'normal', '#ff6b6b', '#4dabf7'),
+      renderBlendDemo(560, 310, 'multiply', '#ff6b6b', '#4dabf7'),
+      renderBlendDemo(670, 310, 'screen', '#ff6b6b', '#4dabf7'),
+
+      // Section 6: Combined — animated dashed arc
+      text({ x: 60, y: 440, text: 'Combined Features', fontSize: 16, fill: '#333', baseline: 'top' as const }),
+      // Animated dashed arcs
+      arc({
+        x: 150, y: 520,
+        radius: 45,
+        startAngle: 0,
+        endAngle: Math.PI * 1.5,
+        stroke: '#4dabf7',
+        strokeWidth: 4,
+        lineCap: 'round',
+        lineDash: [8, 6],
+        lineDashOffset: dashOffset
+      }),
+      arc({
+        x: 150, y: 520,
+        radius: 35,
+        startAngle: Math.PI * 0.5,
+        endAngle: Math.PI * 2,
+        stroke: '#ff6b6b',
+        strokeWidth: 4,
+        lineCap: 'round',
+        lineDash: [8, 6],
+        lineDashOffset: -dashOffset
+      }),
+
+      // Dashed rounded rectangle with round line join
+      rectangle({
+        x: 250, y: 470,
+        dx: 200, dy: 100,
+        stroke: '#51cf66',
+        strokeWidth: 3,
+        cornerRadius: 15,
+        lineDash: [12, 6],
+        lineDashOffset: dashOffset,
+        lineJoin: 'round'
+      }),
+      text({ x: 350, y: 520, text: 'Animated border', fontSize: 14, fill: '#333', align: 'center' as const, baseline: 'middle' as const }),
+
+      // Dashed circle with animated offset
+      circle({
+        x: 560, y: 520,
+        radius: 45,
+        stroke: '#845ef7',
+        strokeWidth: 3,
+        lineDash: [6, 4],
+        lineDashOffset: dashOffset,
+        fill: '#e5dbff'
+      }),
+      text({ x: 560, y: 520, text: 'Loading…', fontSize: 12, fill: '#5f3dc4', align: 'center' as const, baseline: 'middle' as const })
+    ]);
+  }
+};
+
+/** Generate an SVG path for a 5-pointed star. */
+function starPath(cx: number, cy: number, outerR: number, innerR: number): string {
+  const points: string[] = [];
+  for (let i = 0; i < 10; i++) {
+    const angle = (Math.PI / 5) * i - Math.PI / 2;
+    const r = i % 2 === 0 ? outerR : innerR;
+    const x = cx + r * Math.cos(angle);
+    const y = cy + r * Math.sin(angle);
+    points.push(`${i === 0 ? 'M' : 'L'} ${x.toFixed(1)} ${y.toFixed(1)}`);
+  }
+  return points.join(' ') + ' Z';
+}
+
+/** Render a blend mode comparison tile. */
+function renderBlendDemo(x: number, y: number, mode: string, col1: string, col2: string) {
+  return group({ x, y }, [
+    text({ x: 30, y: -2, text: mode, fontSize: 11, fill: '#666', align: 'center' as const, baseline: 'bottom' as const }),
+    layer({ blendMode: mode as any }, [
+      rectangle({ x: 0, y: 0, dx: 40, dy: 40, fill: col1 }),
+      rectangle({ x: 20, y: 15, dx: 40, dy: 40, fill: col2 })
+    ])
+  ]);
+}

--- a/examples/gallery.ts
+++ b/examples/gallery.ts
@@ -43,6 +43,7 @@ import { demo as snakeDemo } from './demos/snake.ts';
 import { demo as guiFormDemo } from './demos/gui-form.ts';
 import { demo as guiDashboardDemo } from './demos/gui-dashboard.ts';
 import { demo as guiGalleryDemo } from './demos/gui-gallery.ts';
+import { demo as lineStylesDemo } from './demos/line-styles.ts';
 
 // Demo registry
 const demos: GalleryDemo[] = [
@@ -55,6 +56,7 @@ const demos: GalleryDemo[] = [
   { ...mindMapDemo, category: 'productivity' },
   { ...particlesDemo, category: 'creative' },
   { ...patternsDemo, category: 'creative' },
+  { ...lineStylesDemo, category: 'creative' },
   { ...clockDemo, category: 'creative' },
   { ...colorPickerDemo, category: 'ui' },
   { ...guiFormDemo, category: 'ui' },

--- a/src/core/context.ts
+++ b/src/core/context.ts
@@ -40,6 +40,14 @@ export class Canvas2DContext implements RenderContext {
     this.transformStack = new TransformStack();
   }
 
+  /** Apply optional line-style props (lineCap, lineJoin, lineDash, lineDashOffset) to the context. */
+  private applyLineStyle(props: any): void {
+    if (props.lineCap) this.ctx.lineCap = props.lineCap;
+    if (props.lineJoin) this.ctx.lineJoin = props.lineJoin;
+    if (props.lineDash) this.ctx.setLineDash(props.lineDash);
+    if (props.lineDashOffset !== undefined) this.ctx.lineDashOffset = props.lineDashOffset;
+  }
+
   save(): void {
     this.ctx.save();
     this.transformStack.save();
@@ -79,6 +87,7 @@ export class Canvas2DContext implements RenderContext {
         this.ctx.fillRect(xl, yl, dxl, dyl);
       }
       if (stroke) {
+        this.applyLineStyle(props);
         this.ctx.strokeStyle = stroke;
         this.ctx.lineWidth = strokeWidth ?? 1;
         this.ctx.strokeRect(xl, yl, dxl, dyl);
@@ -105,6 +114,7 @@ export class Canvas2DContext implements RenderContext {
       this.ctx.fill();
     }
     if (stroke) {
+      this.applyLineStyle(props);
       this.ctx.strokeStyle = stroke;
       this.ctx.lineWidth = strokeWidth ?? 1;
       this.ctx.stroke();
@@ -112,14 +122,15 @@ export class Canvas2DContext implements RenderContext {
   }
 
   drawCircle(xl: number, yl: number, rl: number, props: any): void {
-    const { fill, stroke, strokeWidth } = props;
+    const { fill, stroke, strokeWidth, fillRule } = props;
     this.ctx.beginPath();
     this.ctx.arc(xl, yl, rl, 0, Math.PI * 2);
     if (fill) {
       this.ctx.fillStyle = fill;
-      this.ctx.fill();
+      this.ctx.fill(fillRule ?? 'nonzero');
     }
     if (stroke) {
+      this.applyLineStyle(props);
       this.ctx.strokeStyle = stroke;
       this.ctx.lineWidth = strokeWidth ?? 1;
       this.ctx.stroke();
@@ -127,14 +138,15 @@ export class Canvas2DContext implements RenderContext {
   }
 
   drawEllipse(xl: number, yl: number, rxl: number, ryl: number, props: any): void {
-    const { fill, stroke, strokeWidth } = props;
+    const { fill, stroke, strokeWidth, fillRule } = props;
     this.ctx.beginPath();
     this.ctx.ellipse(xl, yl, rxl, ryl, 0, 0, Math.PI * 2);
     if (fill) {
       this.ctx.fillStyle = fill;
-      this.ctx.fill();
+      this.ctx.fill(fillRule ?? 'nonzero');
     }
     if (stroke) {
+      this.applyLineStyle(props);
       this.ctx.strokeStyle = stroke;
       this.ctx.lineWidth = strokeWidth ?? 1;
       this.ctx.stroke();
@@ -142,13 +154,14 @@ export class Canvas2DContext implements RenderContext {
   }
 
   drawPath(pathData: string, props: any): void {
-    const { fill, stroke, strokeWidth } = props;
+    const { fill, stroke, strokeWidth, fillRule } = props;
     const path = new Path2D(pathData);
     if (fill) {
       this.ctx.fillStyle = fill;
-      this.ctx.fill(path);
+      this.ctx.fill(path, fillRule ?? 'nonzero');
     }
     if (stroke) {
+      this.applyLineStyle(props);
       this.ctx.strokeStyle = stroke;
       this.ctx.lineWidth = strokeWidth ?? 1;
       this.ctx.stroke(path);
@@ -160,6 +173,7 @@ export class Canvas2DContext implements RenderContext {
     this.ctx.beginPath();
     this.ctx.moveTo(xl1, yl1);
     this.ctx.lineTo(xl2, yl2);
+    this.applyLineStyle(props);
     this.ctx.strokeStyle = stroke;
     this.ctx.lineWidth = strokeWidth ?? 1;
     this.ctx.stroke();
@@ -195,6 +209,7 @@ export class Canvas2DContext implements RenderContext {
       this.ctx.fillText(text, xl, yl);
     }
     if (stroke) {
+      this.applyLineStyle(props);
       this.ctx.strokeStyle = stroke;
       this.ctx.lineWidth = strokeWidth ?? 1;
       this.ctx.strokeText(text, xl, yl);
@@ -206,14 +221,15 @@ export class Canvas2DContext implements RenderContext {
   }
 
   drawArc(xl: number, yl: number, rl: number, startAngle: number, endAngle: number, props: any): void {
-    const { fill, stroke, strokeWidth } = props;
+    const { fill, stroke, strokeWidth, fillRule } = props;
     this.ctx.beginPath();
     this.ctx.arc(xl, yl, rl, startAngle, endAngle);
     if (fill) {
       this.ctx.fillStyle = fill;
-      this.ctx.fill();
+      this.ctx.fill(fillRule ?? 'nonzero');
     }
     if (stroke) {
+      this.applyLineStyle(props);
       this.ctx.strokeStyle = stroke;
       this.ctx.lineWidth = strokeWidth ?? 1;
       this.ctx.stroke();

--- a/src/core/renderer-immediate.ts
+++ b/src/core/renderer-immediate.ts
@@ -371,6 +371,17 @@ export class ImmediateRenderer {
         return;
       case BlockType.Group:
       case BlockType.Layer: {
+        // Apply blend mode for Layer blocks
+        if (block.type === BlockType.Layer) {
+          const { blendMode } = props as any;
+          if (blendMode) {
+            const ctx = (this.context as any).ctx as CanvasRenderingContext2D;
+            if (ctx) {
+              ctx.globalCompositeOperation = blendMode;
+            }
+          }
+        }
+
         // Apply clipping if clip is set with dimensions
         const { clip, dx: dxClip, dy: dyClip } = props as any;
         if (clip && dxClip !== undefined && dyClip !== undefined) {

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -52,9 +52,17 @@ export interface BaseBlockProps extends Transform, EventHandlers {
   tooltip?: () => string | Block;
 }
 
+export type LineCap = 'butt' | 'round' | 'square';
+export type LineJoin = 'bevel' | 'round' | 'miter';
+export type FillRule = 'nonzero' | 'evenodd';
+
 export interface StrokeProps {
   stroke?: Color;
   strokeWidth?: number;
+  lineCap?: LineCap;
+  lineJoin?: LineJoin;
+  lineDash?: number[];
+  lineDashOffset?: number;
 }
 
 export interface FillProps {
@@ -138,12 +146,14 @@ export interface TextProps extends BaseBlockProps, StrokeProps, FillProps {
 export interface PathProps extends BaseBlockProps, StrokeProps, FillProps {
   pathData: string; // SVG path format
   closed?: boolean;
+  fillRule?: FillRule;
 }
 
 export interface ArcProps extends BaseBlockProps, StrokeProps, FillProps {
   radius: number;
   startAngle: number;
   endAngle: number;
+  fillRule?: FillRule;
 }
 
 export interface ImageProps extends BaseBlockProps, Rs {


### PR DESCRIPTION
## Canvas 2D Feature Gaps — Phase 1: Quick Wins

### Changes

**Line styling props** (added to `StrokeProps`, applied in all context stroke methods):
- `lineCap`: `'butt' | 'round' | 'square'`
- `lineJoin`: `'bevel' | 'round' | 'miter'`
- `lineDash`: `number[]` (dash pattern)
- `lineDashOffset`: `number` (animated dashes)

**Fill rule** (added to `PathProps` and `ArcProps`):
- `fillRule`: `'nonzero' | 'evenodd'` — controls how overlapping sub-paths are filled

**Blend modes wired up**:
- `Layer.blendMode` was declared in types but never applied to the canvas context
- Now sets `globalCompositeOperation` during Layer rendering

### Demo
New **Line Styles & Blend Modes** gallery demo showcasing:
- Line cap comparison (butt, round, square)
- Line join comparison (miter, round, bevel)
- Dash patterns including animated dash offset
- Dashed shapes (rectangle, circle, ellipse)
- Fill rule comparison (nonzero vs evenodd on a star path)
- Blend mode comparison (normal, multiply, screen)
- Combined features (animated dashed arcs, loading spinner)