### PR TITLE
Phase 2: Gradient and pattern fill support

### DIFF
--- a/examples/demos/gradients.ts
+++ b/examples/demos/gradients.ts
@@ -1,0 +1,262 @@
+// Copyright (c) 2026 François Rouaix
+
+// Gradients & Patterns Demo — showcases Phase 2 Canvas features
+import {
+  group, rectangle, text, circle, ellipse, arc, path,
+  linearGradient, radialGradient, conicGradient, stop
+} from 'vitrine';
+
+export const demo = {
+  id: 'gradients',
+  name: 'Gradients & Patterns',
+  description: 'Linear, radial, and conic gradients with pattern fills',
+
+  init: () => {
+    return { time: 0 };
+  },
+
+  update: (state: { time: number }, dt: number) => {
+    state.time += dt;
+  },
+
+  render: (state: { time: number }) => {
+    const t = state.time;
+
+    return group({ x: 0, y: 0 }, [
+      rectangle({ dx: 800, dy: 600, fill: '#f8f9fa' }),
+
+      // --- Section 1: Linear gradients ---
+      text({ x: 60, y: 25, text: 'Linear Gradients', fontSize: 16, fill: '#333', baseline: 'top' as const }),
+
+      // Horizontal
+      rectangle({
+        x: 20, y: 55, dx: 160, dy: 80,
+        fill: linearGradient(0, 0, 160, 0, [
+          stop(0, '#4dabf7'),
+          stop(1, '#ff6b6b')
+        ]),
+        cornerRadius: 8
+      }),
+      text({ x: 100, y: 150, text: 'horizontal', fontSize: 11, fill: '#666', align: 'center' as const, baseline: 'top' as const }),
+
+      // Vertical
+      rectangle({
+        x: 200, y: 55, dx: 160, dy: 80,
+        fill: linearGradient(0, 0, 0, 80, [
+          stop(0, '#51cf66'),
+          stop(1, '#845ef7')
+        ]),
+        cornerRadius: 8
+      }),
+      text({ x: 280, y: 150, text: 'vertical', fontSize: 11, fill: '#666', align: 'center' as const, baseline: 'top' as const }),
+
+      // Diagonal with multiple stops
+      rectangle({
+        x: 380, y: 55, dx: 160, dy: 80,
+        fill: linearGradient(0, 0, 160, 80, [
+          stop(0, '#ff6b6b'),
+          stop(0.33, '#ffd43b'),
+          stop(0.66, '#51cf66'),
+          stop(1, '#4dabf7')
+        ]),
+        cornerRadius: 8
+      }),
+      text({ x: 460, y: 150, text: 'rainbow diagonal', fontSize: 11, fill: '#666', align: 'center' as const, baseline: 'top' as const }),
+
+      // Gradient stroke
+      rectangle({
+        x: 560, y: 55, dx: 160, dy: 80,
+        stroke: linearGradient(0, 0, 160, 0, [
+          stop(0, '#4dabf7'),
+          stop(1, '#ff6b6b')
+        ]),
+        strokeWidth: 4,
+        cornerRadius: 8
+      }),
+      text({ x: 640, y: 150, text: 'gradient stroke', fontSize: 11, fill: '#666', align: 'center' as const, baseline: 'top' as const }),
+
+      // --- Section 2: Radial gradients ---
+      text({ x: 60, y: 175, text: 'Radial Gradients', fontSize: 16, fill: '#333', baseline: 'top' as const }),
+
+      // Basic radial
+      circle({
+        x: 100, y: 260, radius: 50,
+        fill: radialGradient(0, -10, 5, 0, 0, 50, [
+          stop(0, '#ffffff'),
+          stop(0.7, '#4dabf7'),
+          stop(1, '#1864ab')
+        ])
+      }),
+      text({ x: 100, y: 325, text: 'sphere', fontSize: 11, fill: '#666', align: 'center' as const, baseline: 'top' as const }),
+
+      // Glow effect
+      circle({
+        x: 260, y: 260, radius: 50,
+        fill: radialGradient(0, 0, 0, 0, 0, 50, [
+          stop(0, '#ffd43b'),
+          stop(0.5, '#ff922b'),
+          stop(1, 'rgba(255,107,107,0)')
+        ])
+      }),
+      text({ x: 260, y: 325, text: 'glow', fontSize: 11, fill: '#666', align: 'center' as const, baseline: 'top' as const }),
+
+      // Bullseye
+      circle({
+        x: 420, y: 260, radius: 50,
+        fill: radialGradient(0, 0, 0, 0, 0, 50, [
+          stop(0, '#ff6b6b'),
+          stop(0.2, '#ff6b6b'),
+          stop(0.2, '#fff'),
+          stop(0.4, '#fff'),
+          stop(0.4, '#ff6b6b'),
+          stop(0.6, '#ff6b6b'),
+          stop(0.6, '#fff'),
+          stop(0.8, '#fff'),
+          stop(0.8, '#ff6b6b'),
+          stop(1, '#ff6b6b')
+        ])
+      }),
+      text({ x: 420, y: 325, text: 'bullseye', fontSize: 11, fill: '#666', align: 'center' as const, baseline: 'top' as const }),
+
+      // Radial on ellipse
+      ellipse({
+        x: 580, y: 260, radiusX: 70, radiusY: 40,
+        fill: radialGradient(0, 0, 0, 0, 0, 70, [
+          stop(0, '#e5dbff'),
+          stop(1, '#845ef7')
+        ])
+      }),
+      text({ x: 580, y: 325, text: 'ellipse', fontSize: 11, fill: '#666', align: 'center' as const, baseline: 'top' as const }),
+
+      // --- Section 3: Conic gradients ---
+      text({ x: 60, y: 350, text: 'Conic Gradients', fontSize: 16, fill: '#333', baseline: 'top' as const }),
+
+      // Color wheel
+      circle({
+        x: 100, y: 435, radius: 50,
+        fill: conicGradient(0, 0, 0, [
+          stop(0, '#ff6b6b'),
+          stop(0.17, '#ffd43b'),
+          stop(0.33, '#51cf66'),
+          stop(0.5, '#4dabf7'),
+          stop(0.67, '#845ef7'),
+          stop(0.83, '#ff6b6b'),
+          stop(1, '#ff6b6b')
+        ])
+      }),
+      text({ x: 100, y: 500, text: 'color wheel', fontSize: 11, fill: '#666', align: 'center' as const, baseline: 'top' as const }),
+
+      // Sweep gauge
+      arc({
+        x: 260, y: 435, radius: 50,
+        startAngle: -Math.PI * 0.75,
+        endAngle: Math.PI * 0.75,
+        fill: conicGradient(-Math.PI * 0.75, 0, 0, [
+          stop(0, '#51cf66'),
+          stop(0.5, '#ffd43b'),
+          stop(1, '#ff6b6b')
+        ]),
+        stroke: '#333',
+        strokeWidth: 1
+      }),
+      text({ x: 260, y: 500, text: 'sweep gauge', fontSize: 11, fill: '#666', align: 'center' as const, baseline: 'top' as const }),
+
+      // Animated conic
+      circle({
+        x: 420, y: 435, radius: 50,
+        fill: conicGradient(t * 2, 0, 0, [
+          stop(0, '#4dabf7'),
+          stop(0.5, '#ff6b6b'),
+          stop(1, '#4dabf7')
+        ])
+      }),
+      text({ x: 420, y: 500, text: 'animated', fontSize: 11, fill: '#666', align: 'center' as const, baseline: 'top' as const }),
+
+      // Pie chart with conic gradient
+      circle({
+        x: 580, y: 435, radius: 50,
+        fill: conicGradient(0, 0, 0, [
+          stop(0, '#4dabf7'),
+          stop(0.35, '#4dabf7'),
+          stop(0.35, '#51cf66'),
+          stop(0.6, '#51cf66'),
+          stop(0.6, '#ffd43b'),
+          stop(0.85, '#ffd43b'),
+          stop(0.85, '#ff6b6b'),
+          stop(1, '#ff6b6b')
+        ]),
+        stroke: '#fff',
+        strokeWidth: 2
+      }),
+      text({ x: 580, y: 500, text: 'pie chart', fontSize: 11, fill: '#666', align: 'center' as const, baseline: 'top' as const }),
+
+      // --- Section 4: Gradient combinations ---
+      text({ x: 60, y: 525, text: 'Combinations', fontSize: 16, fill: '#333', baseline: 'top' as const }),
+
+      // Gradient-filled path
+      path({
+        pathData: starPath(120, 570, 30, 12),
+        fill: linearGradient(90, 540, 150, 600, [
+          stop(0, '#ffd43b'),
+          stop(1, '#ff922b')
+        ]),
+        stroke: '#e67700',
+        strokeWidth: 1
+      }),
+      text({ x: 120, y: 605, text: 'star', fontSize: 11, fill: '#666', align: 'center' as const, baseline: 'top' as const }),
+
+      // Button-like gradient
+      rectangle({
+        x: 190, y: 548, dx: 120, dy: 40,
+        fill: linearGradient(0, 0, 0, 40, [
+          stop(0, '#51cf66'),
+          stop(1, '#2f9e44')
+        ]),
+        cornerRadius: 20
+      }),
+      text({ x: 250, y: 568, text: 'Button', fontSize: 14, fill: '#fff', align: 'center' as const, baseline: 'middle' as const }),
+
+      // Progress bar with gradient
+      group({ x: 340, y: 548 }, [
+        rectangle({ dx: 200, dy: 24, fill: '#e9ecef', cornerRadius: 12 }),
+        rectangle({
+          dx: 140, dy: 24,
+          fill: linearGradient(0, 0, 140, 0, [
+            stop(0, '#4dabf7'),
+            stop(1, '#845ef7')
+          ]),
+          cornerRadius: 12
+        }),
+        text({ x: 70, y: 12, text: '70%', fontSize: 12, fill: '#fff', align: 'center' as const, baseline: 'middle' as const })
+      ]),
+
+      // Metallic effect
+      rectangle({
+        x: 570, y: 548, dx: 100, dy: 40,
+        fill: linearGradient(0, 0, 0, 40, [
+          stop(0, '#e0e0e0'),
+          stop(0.3, '#ffffff'),
+          stop(0.5, '#c0c0c0'),
+          stop(0.7, '#ffffff'),
+          stop(1, '#a0a0a0')
+        ]),
+        stroke: '#888',
+        strokeWidth: 1,
+        cornerRadius: 4
+      }),
+      text({ x: 620, y: 568, text: 'Metallic', fontSize: 12, fill: '#444', align: 'center' as const, baseline: 'middle' as const })
+    ]);
+  }
+};
+
+function starPath(cx: number, cy: number, outerR: number, innerR: number): string {
+  const points: string[] = [];
+  for (let i = 0; i < 10; i++) {
+    const angle = (Math.PI / 5) * i - Math.PI / 2;
+    const r = i % 2 === 0 ? outerR : innerR;
+    const x = cx + r * Math.cos(angle);
+    const y = cy + r * Math.sin(angle);
+    points.push(`${i === 0 ? 'M' : 'L'} ${x.toFixed(1)} ${y.toFixed(1)}`);
+  }
+  return points.join(' ') + ' Z';
+}

--- a/examples/gallery.ts
+++ b/examples/gallery.ts
@@ -44,6 +44,7 @@ import { demo as guiFormDemo } from './demos/gui-form.ts';
 import { demo as guiDashboardDemo } from './demos/gui-dashboard.ts';
 import { demo as guiGalleryDemo } from './demos/gui-gallery.ts';
 import { demo as lineStylesDemo } from './demos/line-styles.ts';
+import { demo as gradientsDemo } from './demos/gradients.ts';
 
 // Demo registry
 const demos: GalleryDemo[] = [
@@ -57,6 +58,7 @@ const demos: GalleryDemo[] = [
   { ...particlesDemo, category: 'creative' },
   { ...patternsDemo, category: 'creative' },
   { ...lineStylesDemo, category: 'creative' },
+  { ...gradientsDemo, category: 'creative' },
   { ...clockDemo, category: 'creative' },
   { ...colorPickerDemo, category: 'ui' },
   { ...guiFormDemo, category: 'ui' },

--- a/src/core/fill-styles.ts
+++ b/src/core/fill-styles.ts
@@ -1,0 +1,51 @@
+// Copyright (c) 2026 François Rouaix
+
+// Factory functions for gradient and pattern descriptors
+import type {
+  ColorStop,
+  LinearGradientDescriptor,
+  RadialGradientDescriptor,
+  ConicGradientDescriptor,
+  PatternDescriptor,
+  Color
+} from './types.ts';
+
+/** Create a linear gradient descriptor. */
+export function linearGradient(
+  x0: number, y0: number,
+  x1: number, y1: number,
+  stops: ColorStop[]
+): LinearGradientDescriptor {
+  return { type: 'linear-gradient', x0, y0, x1, y1, stops };
+}
+
+/** Create a radial gradient descriptor. */
+export function radialGradient(
+  x0: number, y0: number, r0: number,
+  x1: number, y1: number, r1: number,
+  stops: ColorStop[]
+): RadialGradientDescriptor {
+  return { type: 'radial-gradient', x0, y0, r0, x1, y1, r1, stops };
+}
+
+/** Create a conic gradient descriptor. */
+export function conicGradient(
+  startAngle: number,
+  x: number, y: number,
+  stops: ColorStop[]
+): ConicGradientDescriptor {
+  return { type: 'conic-gradient', startAngle, x, y, stops };
+}
+
+/** Create a pattern descriptor from an image or canvas element. */
+export function pattern(
+  image: HTMLImageElement | HTMLCanvasElement,
+  repetition: 'repeat' | 'repeat-x' | 'repeat-y' | 'no-repeat' = 'repeat'
+): PatternDescriptor {
+  return { type: 'pattern', image, repetition };
+}
+
+/** Convenience: create a color stop. */
+export function stop(offset: number, color: Color): ColorStop {
+  return { offset, color };
+}

--- a/src/core/renderer-webgl.ts
+++ b/src/core/renderer-webgl.ts
@@ -229,8 +229,8 @@ export class WebGLRenderer extends Renderer {
     return texture;
   }
 
-  private parseColor(color: string | undefined, opacity: number): RGBA {
-    if (!color) return [0, 0, 0, 0];
+  private parseColor(color: any, opacity: number): RGBA {
+    if (!color || typeof color !== 'string') return [0, 0, 0, 0];
 
     const key = `${color}|${opacity}`;
     const cached = this.colorCache.get(key);
@@ -468,11 +468,11 @@ export class WebGLRenderer extends Renderer {
       const pathProps = props as PathProps;
       const path = new Path2D(pathProps.pathData);
       if (pathProps.fill) {
-        this.fallbackCtx.fillStyle = pathProps.fill;
+        this.fallbackCtx.fillStyle = typeof pathProps.fill === 'string' ? pathProps.fill : 'transparent';
         this.fallbackCtx.fill(path);
       }
       if (pathProps.stroke) {
-        this.fallbackCtx.strokeStyle = pathProps.stroke;
+        this.fallbackCtx.strokeStyle = typeof pathProps.stroke === 'string' ? pathProps.stroke : 'transparent';
         this.fallbackCtx.lineWidth = pathProps.strokeWidth ?? 1;
         this.fallbackCtx.stroke(path);
       }
@@ -633,11 +633,11 @@ export class WebGLRenderer extends Renderer {
     const anchorY = -yMin + pad;
 
     if (fill) {
-      ctx.fillStyle = fill;
+      ctx.fillStyle = typeof fill === 'string' ? fill : 'transparent';
       ctx.fillText(stText, anchorX, anchorY);
     }
     if (stroke) {
-      ctx.strokeStyle = stroke;
+      ctx.strokeStyle = typeof stroke === 'string' ? stroke : 'transparent';
       ctx.lineWidth = strokeWidth;
       ctx.strokeText(stText, anchorX, anchorY);
     }

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -5,6 +5,52 @@
 export type Color = string; // CSS color format
 export type BlendMode = 'normal' | 'multiply' | 'screen' | 'overlay' | 'darken' | 'lighten';
 
+// --- Gradient & Pattern descriptors ---
+
+export interface ColorStop {
+  offset: number; // 0–1
+  color: Color;
+}
+
+export interface LinearGradientDescriptor {
+  type: 'linear-gradient';
+  x0: number;
+  y0: number;
+  x1: number;
+  y1: number;
+  stops: ColorStop[];
+}
+
+export interface RadialGradientDescriptor {
+  type: 'radial-gradient';
+  x0: number;
+  y0: number;
+  r0: number;
+  x1: number;
+  y1: number;
+  r1: number;
+  stops: ColorStop[];
+}
+
+export interface ConicGradientDescriptor {
+  type: 'conic-gradient';
+  startAngle: number;
+  x: number;
+  y: number;
+  stops: ColorStop[];
+}
+
+export type GradientDescriptor = LinearGradientDescriptor | RadialGradientDescriptor | ConicGradientDescriptor;
+
+export interface PatternDescriptor {
+  type: 'pattern';
+  image: HTMLImageElement | HTMLCanvasElement;
+  repetition?: 'repeat' | 'repeat-x' | 'repeat-y' | 'no-repeat';
+}
+
+/** Any value accepted by fill or stroke properties. */
+export type FillStyle = Color | GradientDescriptor | PatternDescriptor;
+
 /** Pointer event enriched with Vitrine coordinate data. */
 export type VitrinePointerEvent = PointerEvent & {
   /** Block-local X coordinate (after all parent+block transforms inverted) */
@@ -57,7 +103,7 @@ export type LineJoin = 'bevel' | 'round' | 'miter';
 export type FillRule = 'nonzero' | 'evenodd';
 
 export interface StrokeProps {
-  stroke?: Color;
+  stroke?: FillStyle;
   strokeWidth?: number;
   lineCap?: LineCap;
   lineJoin?: LineJoin;
@@ -66,7 +112,7 @@ export interface StrokeProps {
 }
 
 export interface FillProps {
-  fill?: Color;
+  fill?: FillStyle;
 }
 
 export interface Rs {
@@ -132,7 +178,7 @@ export interface LineProps extends BaseBlockProps, StrokeProps {
   y1: number;
   x2: number;
   y2: number;
-  stroke: Color;
+  stroke: FillStyle;
 }
 
 export interface TextProps extends BaseBlockProps, StrokeProps, FillProps {

--- a/src/index.ts
+++ b/src/index.ts
@@ -27,6 +27,9 @@ export type { HitTestResult } from './hit-test.ts';
 // Block factory functions
 export * from './core/blocks.ts';
 
+// Gradient & pattern factories
+export * from './core/fill-styles.ts';
+
 // GUI components
 export {
   // Types


### PR DESCRIPTION
## Canvas 2D Feature Gaps — Phase 2: Gradients & Patterns

### New types

**Gradient descriptors** (pure data, no canvas objects):
- `LinearGradientDescriptor` — `x0, y0, x1, y1` + color stops
- `RadialGradientDescriptor` — `x0, y0, r0, x1, y1, r1` + color stops
- `ConicGradientDescriptor` — `startAngle, x, y` + color stops
- `PatternDescriptor` — `image` (HTMLImageElement | HTMLCanvasElement) + `repetition`

**`FillStyle` union type**: `Color | GradientDescriptor | PatternDescriptor`
- `fill` and `stroke` props on all blocks now accept `FillStyle`
- Backward compatible — plain CSS color strings still work

### Factory functions (`src/core/fill-styles.ts`)
```typescript
linearGradient(x0, y0, x1, y1, stops)
radialGradient(x0, y0, r0, x1, y1, r1, stops)
conicGradient(startAngle, x, y, stops)
pattern(image, repetition?)
stop(offset, color)  // convenience for { offset, color }
```

### Context integration
`Canvas2DContext.resolveFillStyle()` converts descriptors to native `CanvasGradient` / `CanvasPattern` objects. Called transparently wherever `fillStyle` or `strokeStyle` is set.

### Demo
New **Gradients & Patterns** gallery demo:
- Linear: horizontal, vertical, rainbow diagonal, gradient stroke
- Radial: 3D sphere highlight, glow effect, bullseye rings, ellipse
- Conic: color wheel, sweep gauge, animated rotation, pie chart
- Combinations: gradient star path, button, progress bar, metallic effect