### PR TITLE
feat: Text wrapping support

### DIFF
--- a/examples/demos/text-wrapping.ts
+++ b/examples/demos/text-wrapping.ts
@@ -1,0 +1,126 @@
+// Copyright (c) 2026 François Rouaix
+
+// Text Wrapping Demo — showcases word-wrap, alignment, clipping, and line height
+import { group, rectangle, text } from 'vitrine';
+
+const LOREM = 'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris.';
+const SHORT = 'Hello, this is a short sentence that should wrap to multiple lines.';
+
+export const demo = {
+  id: 'text-wrapping',
+  name: 'Text Wrapping',
+  description: 'Word wrapping with dx, vertical clipping with dy, alignment, and line height',
+
+  init: () => {
+    return { time: 0 };
+  },
+
+  update: (state: { time: number }, dt: number) => {
+    state.time += dt;
+  },
+
+  render: (state: { time: number }) => {
+    const col = { bg: '#f8f9fa', heading: '#333', label: '#666', box: '#e9ecef', border: '#dee2e6' };
+
+    return group({ x: 0, y: 0 }, [
+      rectangle({ dx: 800, dy: 700, fill: col.bg }),
+
+      // ── Section 1: Basic word wrap ──
+      text({ x: 20, y: 25, text: 'Basic Word Wrap (dx)', fontSize: 16, fill: col.heading, baseline: 'top' as const }),
+
+      // No dx — single line (reference)
+      text({ x: 20, y: 55, text: 'No dx (single line):', fontSize: 11, fill: col.label, baseline: 'top' as const }),
+      text({ x: 20, y: 72, text: SHORT, fontSize: 13, fill: '#222', baseline: 'top' as const }),
+
+      // dx: 200
+      text({ x: 20, y: 95, text: 'dx: 200', fontSize: 11, fill: col.label, baseline: 'top' as const }),
+      rectangle({ x: 20, y: 112, dx: 200, dy: 80, fill: col.box, stroke: col.border, strokeWidth: 1 }),
+      text({ x: 20, y: 112, text: SHORT, fontSize: 13, fill: '#222', baseline: 'top' as const, dx: 200 }),
+
+      // dx: 350
+      text({ x: 250, y: 95, text: 'dx: 350', fontSize: 11, fill: col.label, baseline: 'top' as const }),
+      rectangle({ x: 250, y: 112, dx: 350, dy: 80, fill: col.box, stroke: col.border, strokeWidth: 1 }),
+      text({ x: 250, y: 112, text: SHORT, fontSize: 13, fill: '#222', baseline: 'top' as const, dx: 350 }),
+
+      // dx: 120 — narrow
+      text({ x: 630, y: 95, text: 'dx: 120 (narrow)', fontSize: 11, fill: col.label, baseline: 'top' as const }),
+      rectangle({ x: 630, y: 112, dx: 120, dy: 120, fill: col.box, stroke: col.border, strokeWidth: 1 }),
+      text({ x: 630, y: 112, text: SHORT, fontSize: 13, fill: '#222', baseline: 'top' as const, dx: 120 }),
+
+      // ── Section 2: Alignment ──
+      text({ x: 20, y: 245, text: 'Alignment', fontSize: 16, fill: col.heading, baseline: 'top' as const }),
+
+      // Left align (default)
+      text({ x: 20, y: 275, text: 'align: left', fontSize: 11, fill: col.label, baseline: 'top' as const }),
+      rectangle({ x: 20, y: 292, dx: 200, dy: 75, fill: col.box, stroke: col.border, strokeWidth: 1 }),
+      text({ x: 20, y: 292, text: SHORT, fontSize: 13, fill: '#222', baseline: 'top' as const, dx: 200, align: 'left' as const }),
+
+      // Center align
+      text({ x: 250, y: 275, text: 'align: center', fontSize: 11, fill: col.label, baseline: 'top' as const }),
+      rectangle({ x: 250, y: 292, dx: 200, dy: 75, fill: col.box, stroke: col.border, strokeWidth: 1 }),
+      text({ x: 350, y: 292, text: SHORT, fontSize: 13, fill: '#222', baseline: 'top' as const, dx: 200, align: 'center' as const }),
+
+      // Right align
+      text({ x: 480, y: 275, text: 'align: right', fontSize: 11, fill: col.label, baseline: 'top' as const }),
+      rectangle({ x: 480, y: 292, dx: 200, dy: 75, fill: col.box, stroke: col.border, strokeWidth: 1 }),
+      text({ x: 680, y: 292, text: SHORT, fontSize: 13, fill: '#222', baseline: 'top' as const, dx: 200, align: 'right' as const }),
+
+      // ── Section 3: Vertical clipping (dy) ──
+      text({ x: 20, y: 380, text: 'Vertical Clipping (dy)', fontSize: 16, fill: col.heading, baseline: 'top' as const }),
+
+      // No dy — all lines visible
+      text({ x: 20, y: 410, text: 'No dy (all lines)', fontSize: 11, fill: col.label, baseline: 'top' as const }),
+      rectangle({ x: 20, y: 427, dx: 200, dy: 120, fill: col.box, stroke: col.border, strokeWidth: 1 }),
+      text({ x: 20, y: 427, text: LOREM, fontSize: 12, fill: '#222', baseline: 'top' as const, dx: 200 }),
+
+      // dy: 55 — clipped
+      text({ x: 250, y: 410, text: 'dy: 55 (clipped)', fontSize: 11, fill: col.label, baseline: 'top' as const }),
+      rectangle({ x: 250, y: 427, dx: 200, dy: 55, fill: col.box, stroke: '#e03131', strokeWidth: 1 }),
+      text({ x: 250, y: 427, text: LOREM, fontSize: 12, fill: '#222', baseline: 'top' as const, dx: 200, dy: 55 }),
+
+      // dy: 90 — more room
+      text({ x: 480, y: 410, text: 'dy: 90 (more room)', fontSize: 11, fill: col.label, baseline: 'top' as const }),
+      rectangle({ x: 480, y: 427, dx: 200, dy: 90, fill: col.box, stroke: '#2f9e44', strokeWidth: 1 }),
+      text({ x: 480, y: 427, text: LOREM, fontSize: 12, fill: '#222', baseline: 'top' as const, dx: 200, dy: 90 }),
+
+      // ── Section 4: Line height ──
+      text({ x: 20, y: 565, text: 'Line Height', fontSize: 16, fill: col.heading, baseline: 'top' as const }),
+
+      // Tight (1.0x)
+      text({ x: 20, y: 595, text: 'lineHeight: 13 (tight)', fontSize: 11, fill: col.label, baseline: 'top' as const }),
+      rectangle({ x: 20, y: 612, dx: 180, dy: 65, fill: col.box, stroke: col.border, strokeWidth: 1 }),
+      text({ x: 20, y: 612, text: SHORT, fontSize: 13, fill: '#222', baseline: 'top' as const, dx: 180, lineHeight: 13 }),
+
+      // Default (1.4x)
+      text({ x: 220, y: 595, text: 'lineHeight: default (1.4×)', fontSize: 11, fill: col.label, baseline: 'top' as const }),
+      rectangle({ x: 220, y: 612, dx: 180, dy: 85, fill: col.box, stroke: col.border, strokeWidth: 1 }),
+      text({ x: 220, y: 612, text: SHORT, fontSize: 13, fill: '#222', baseline: 'top' as const, dx: 180 }),
+
+      // Spacious (2.0x)
+      text({ x: 420, y: 595, text: 'lineHeight: 26 (spacious)', fontSize: 11, fill: col.label, baseline: 'top' as const }),
+      rectangle({ x: 420, y: 612, dx: 180, dy: 115, fill: col.box, stroke: col.border, strokeWidth: 1 }),
+      text({ x: 420, y: 612, text: SHORT, fontSize: 13, fill: '#222', baseline: 'top' as const, dx: 180, lineHeight: 26 }),
+
+      // ── Section 5: Styled wrapped text ──
+      text({ x: 630, y: 565, text: 'Styled', fontSize: 16, fill: col.heading, baseline: 'top' as const }),
+
+      // Stroked text
+      rectangle({ x: 630, y: 595, dx: 150, dy: 80, fill: '#1a1b2e', stroke: col.border, strokeWidth: 1 }),
+      text({
+        x: 630, y: 595, text: 'Stroked wrapped text with glow effect',
+        fontSize: 14, fill: '#ffd43b', stroke: '#ff6b6b', strokeWidth: 0.5,
+        baseline: 'top' as const, dx: 150
+      }),
+
+      // Animated width
+      ...(() => {
+        const animDx = 100 + Math.sin(state.time * 1.5) * 60;
+        return [
+          text({ x: 630, y: 410, text: `Animated dx: ${Math.round(animDx)}`, fontSize: 11, fill: col.label, baseline: 'top' as const }),
+          rectangle({ x: 630, y: 427, dx: animDx, dy: 120, fill: col.box, stroke: '#7950f2', strokeWidth: 1 }),
+          text({ x: 630, y: 427, text: SHORT, fontSize: 12, fill: '#5f3dc4', baseline: 'top' as const, dx: animDx })
+        ];
+      })()
+    ]);
+  }
+};

--- a/examples/gallery.ts
+++ b/examples/gallery.ts
@@ -46,6 +46,7 @@ import { demo as guiGalleryDemo } from './demos/gui-gallery.ts';
 import { demo as lineStylesDemo } from './demos/line-styles.ts';
 import { demo as gradientsDemo } from './demos/gradients.ts';
 import { demo as imageFiltersDemo } from './demos/image-filters.ts';
+import { demo as textWrappingDemo } from './demos/text-wrapping.ts';
 
 // Demo registry
 const demos: GalleryDemo[] = [
@@ -61,6 +62,7 @@ const demos: GalleryDemo[] = [
   { ...lineStylesDemo, category: 'creative' },
   { ...gradientsDemo, category: 'creative' },
   { ...imageFiltersDemo, category: 'creative' },
+  { ...textWrappingDemo, category: 'creative' },
   { ...clockDemo, category: 'creative' },
   { ...colorPickerDemo, category: 'ui' },
   { ...guiFormDemo, category: 'ui' },

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -188,6 +188,12 @@ export interface TextProps extends BaseBlockProps, StrokeProps, FillProps {
   fontSize?: number;
   align?: 'left' | 'center' | 'right' | 'start' | 'end';
   baseline?: 'top' | 'middle' | 'bottom' | 'alphabetic' | 'hanging';
+  /** When set, word-wrap text to fit within this width. */
+  dx?: number;
+  /** When set (with dx), clip text vertically at this height. */
+  dy?: number;
+  /** Line spacing in pixels. Defaults to fontSize * 1.4. */
+  lineHeight?: number;
 }
 
 export interface PathProps extends BaseBlockProps, StrokeProps, FillProps {

--- a/src/hit-test.ts
+++ b/src/hit-test.ts
@@ -128,12 +128,24 @@ export class HitTester {
 
       case BlockType.Text: {
         // Calculate text bounds accounting for baseline and alignment
-        const { fontSize: duFont, text: stText, align, baseline } = props;
+        const { fontSize: duFont, text: stText, align, baseline, dx: dxMax, lineHeight: lineHeightProp } = props;
         const fontSize = duFont ?? 16;
-        const textWidth = stText.length * fontSize * 0.6; // rough estimate
+        const duLineHeight = lineHeightProp ?? fontSize * 1.4;
+
+        let textWidth: number;
+        let height: number;
+        if (dxMax !== undefined) {
+          // Approximate wrapped line count
+          const singleLineWidth = stText.length * fontSize * 0.6;
+          const lineCount = Math.max(1, Math.ceil(singleLineWidth / dxMax));
+          textWidth = Math.min(singleLineWidth, dxMax);
+          height = lineCount * duLineHeight;
+        } else {
+          textWidth = stText.length * fontSize * 0.6; // rough estimate
+          height = fontSize;
+        }
+
         const ascent = fontSize; // approximate
-        const descent = 0;
-        const height = ascent + descent;
         
         // Calculate x offset based on alignment
         let xOffset = 0;
@@ -309,10 +321,15 @@ export class HitTester {
       }
 
       case BlockType.Text: {
-        const { fontSize: duFont, text: stText } = props;
+        const { fontSize: duFont, text: stText, dx: dxMax, lineHeight: lineHeightProp } = props;
         const fontSize = duFont ?? 16;
-        const textWidth = stText.length * fontSize * 0.6;
-        return { x: 0, y: 0, width: textWidth, height: fontSize };
+        const duLineHeight = lineHeightProp ?? fontSize * 1.4;
+        const singleLineWidth = stText.length * fontSize * 0.6;
+        if (dxMax !== undefined) {
+          const lineCount = Math.max(1, Math.ceil(singleLineWidth / dxMax));
+          return { x: 0, y: 0, width: Math.min(singleLineWidth, dxMax), height: lineCount * duLineHeight };
+        }
+        return { x: 0, y: 0, width: singleLineWidth, height: fontSize };
       }
 
       default:


### PR DESCRIPTION
## Text Wrapping

Adds optional word-wrapping to the `text()` block via three new props on `TextProps`:

### New Props
| Prop | Type | Description |
|------|------|-------------|
| `dx` | `number?` | Wrap width — triggers word-level wrapping at whitespace boundaries |
| `dy` | `number?` | Clip height — when set with `dx`, clips text vertically |
| `lineHeight` | `number?` | Line spacing in pixels (default: `fontSize × 1.4`) |

### Behavior
- **No `dx`**: single-line, unchanged behavior (fully backward-compatible)
- **`dx` set**: word-wrap text to fit within `dx` pixels; each line is a separate `fillText`/`strokeText` call
- **`dy` set** (with `dx`): clips text vertically via canvas clip region — lines beyond `dy` are not visible
- A single word longer than `dx` renders as-is (no forced character break)

### Code Example
```typescript
// Basic wrapping
text({ x: 20, y: 50, text: 'Long paragraph...', dx: 200, fontSize: 14, fill: '#333', baseline: 'top' })

// With vertical clipping
text({ x: 20, y: 50, text: 'Long paragraph...', dx: 200, dy: 80, fontSize: 14, fill: '#333', baseline: 'top' })

// Custom line height
text({ x: 20, y: 50, text: 'Tight spacing', dx: 200, lineHeight: 14, fontSize: 14, fill: '#333', baseline: 'top' })
```

### Changes
- `src/core/types.ts`: Added `dx?`, `dy?`, `lineHeight?` to `TextProps`
- `src/core/context.ts`: `wrapText()` helper, multi-line `drawText()` and `measureText()`
- `src/core/renderer-webgl.ts`: Multi-line texture generation in `getTextTextureEntry()`
- `src/hit-test.ts`: Wrapped text hit-testing and bounding box
- `examples/demos/text-wrapping.ts`: Gallery demo with all cases

### Demo Sections
1. **Basic Word Wrap** — dx at 200, 350, 120 pixels
2. **Alignment** — left, center, right with wrapping
3. **Vertical Clipping** — no dy vs dy:55 vs dy:90
4. **Line Height** — tight (1.0×), default (1.4×), spacious (2.0×)
5. **Styled** — stroked wrapped text + animated wrap width