### PR TITLE
feat(gui): configurable RAF scheduling for VitrineComponent

### DIFF
--- a/docs/BLOCK_DSL.md
+++ b/docs/BLOCK_DSL.md
@@ -817,7 +817,8 @@ myComponent.setTheme(darkTheme);
 // Mark dirty after external state mutation (needed in onDemand/auto when state changes outside component mutators)
 myComponent.invalidate();
 
-// Auto mode animation lifecycle (run RAF while animation count > 0)
+// Optional explicit animation lifecycle for auto mode.
+// Once used, auto mode follows begin/end animation count.
 myComponent.beginAnimation();
 // ...update your animation state from app code...
 myComponent.endAnimation();
@@ -839,7 +840,7 @@ const canvas = myComponent.getCanvas();
 
 - `continuous`: RAF always runs. Best for constantly animated scenes.
 - `onDemand`: renders only when invalidated (for example `invalidate()`, `setTheme()`, `resize()`, or `setRenderFunction()`).
-- `auto`: runs continuously only while `beginAnimation()`/`endAnimation()` indicates active animations; otherwise behaves like on-demand.
+- `auto`: starts as continuous (so time-based animations render without extra wiring). If you call `beginAnimation()` or `endAnimation()`, it switches to explicit animation control and then runs continuously only while animation count is active.
 
 ### 9.5 Auto-sizing
 

--- a/docs/BLOCK_DSL.md
+++ b/docs/BLOCK_DSL.md
@@ -756,7 +756,7 @@ type VitrinePointerEvent = PointerEvent & {
 
 ## 9. `VitrineComponent`
 
-`VitrineComponent` wraps a single Vitrine render function in its own `<canvas>` element. It manages the canvas lifecycle, render loop, and device pixel ratio, making it easy to embed Vitrine inside any HTML page or JavaScript framework (React, Vue, etc.).
+`VitrineComponent` wraps a single Vitrine render function in its own `<canvas>` element. It manages the canvas lifecycle, render scheduling, and device pixel ratio, making it easy to embed Vitrine inside any HTML page or JavaScript framework (React, Vue, etc.).
 
 ### 9.1 Creating a component
 
@@ -795,12 +795,14 @@ const animatedComponent = VitrineComponent.block(
 | `height` | `number` | Canvas height in CSS pixels. If omitted in GUI mode, auto-sized from the root control. |
 | `theme` | `ThemeDefinition` | Theme for GUI controls (GUI mode only). Defaults to `lightTheme`. |
 | `pixelRatio` | `number` | Device pixel ratio override. |
+| `renderMode` | `'continuous' \| 'onDemand' \| 'auto'` | Render scheduler mode. Defaults to `'continuous'`. |
+| `invalidateOnInteraction` | `boolean` | In non-continuous modes, auto-calls `invalidate()` on pointer/wheel interaction. Defaults to `true`. |
 | `rendererConfig` | `Partial<RendererConfig>` | Additional options forwarded to `ImmediateRenderer`. |
 
 ### 9.3 Lifecycle
 
 ```typescript
-// Mount — creates a <canvas>, appends it to the container, starts the render loop
+// Mount — creates a <canvas>, appends it to the container, and starts scheduler-managed rendering
 myComponent.mount(document.getElementById('my-container')!);
 
 // Resize at any time
@@ -812,7 +814,18 @@ myComponent.setRenderFunction(() => /* new tree */);
 // Update the theme (GUI mode only)
 myComponent.setTheme(darkTheme);
 
-// Unmount — stops the render loop, removes the canvas, releases event listeners
+// Mark dirty after external state mutation (needed in onDemand/auto when state changes outside component mutators)
+myComponent.invalidate();
+
+// Auto mode animation lifecycle (run RAF while animation count > 0)
+myComponent.beginAnimation();
+// ...update your animation state from app code...
+myComponent.endAnimation();
+
+// Optional: switch mode at runtime
+myComponent.setRenderMode('onDemand');
+
+// Unmount — stops scheduled rendering, removes the canvas, releases event listeners
 myComponent.unmount();
 
 // Check if currently mounted
@@ -822,7 +835,13 @@ if (myComponent.isMounted()) { /* ... */ }
 const canvas = myComponent.getCanvas();
 ```
 
-### 9.4 Auto-sizing
+### 9.4 Render modes
+
+- `continuous`: RAF always runs. Best for constantly animated scenes.
+- `onDemand`: renders only when invalidated (for example `invalidate()`, `setTheme()`, `resize()`, or `setRenderFunction()`).
+- `auto`: runs continuously only while `beginAnimation()`/`endAnimation()` indicates active animations; otherwise behaves like on-demand.
+
+### 9.5 Auto-sizing
 
 In GUI mode, if `width` or `height` is omitted from the config, the component calls `rsControl()` on the root control to compute the canvas size from the control's natural dimensions:
 
@@ -1010,4 +1029,3 @@ circle({ x: cx, y: cy, radius: 30, fill: '#ff6b6b',
 ```
 
 Supported CSS filter functions include: `blur`, `brightness`, `contrast`, `grayscale`, `hue-rotate`, `invert`, `opacity`, `saturate`, `sepia`, `drop-shadow`.
-

--- a/packages/gui/src/component.ts
+++ b/packages/gui/src/component.ts
@@ -50,6 +50,7 @@ export class VitrineComponent {
   private renderMode: RenderMode;
   private invalidateOnInteraction: boolean;
   private activeAnimationCount: number = 0;
+  private hasExplicitAnimationControl: boolean = false;
   private fDirty: boolean = false;
   private boundInteractionHandlers: {
     pointerdown: () => void;
@@ -125,6 +126,7 @@ export class VitrineComponent {
     this.removeInteractionInvalidation();
     this.fDirty = false;
     this.activeAnimationCount = 0;
+    this.hasExplicitAnimationControl = false;
 
     if (this.renderer) {
       this.renderer.destroy();
@@ -197,6 +199,7 @@ export class VitrineComponent {
    * In auto mode, this enables continuous RAF until endAnimation() balances it.
    */
   beginAnimation(): void {
+    this.hasExplicitAnimationControl = true;
     this.activeAnimationCount += 1;
     this.invalidate();
   }
@@ -206,6 +209,7 @@ export class VitrineComponent {
    * The count is clamped at zero to keep state robust across mismatched calls.
    */
   endAnimation(): void {
+    this.hasExplicitAnimationControl = true;
     this.activeAnimationCount = Math.max(0, this.activeAnimationCount - 1);
     this.invalidate();
   }
@@ -237,6 +241,9 @@ export class VitrineComponent {
       return true;
     }
     if (this.renderMode === 'auto') {
+      if (!this.hasExplicitAnimationControl) {
+        return true;
+      }
       return this.activeAnimationCount > 0;
     }
     return false;

--- a/packages/gui/src/component.ts
+++ b/packages/gui/src/component.ts
@@ -278,7 +278,7 @@ export class VitrineComponent {
     this.canvas.addEventListener('pointermove', this.boundInteractionHandlers.pointermove);
     this.canvas.addEventListener('click', this.boundInteractionHandlers.click);
     this.canvas.addEventListener('pointerleave', this.boundInteractionHandlers.pointerleave);
-    this.canvas.addEventListener('wheel', this.boundInteractionHandlers.wheel);
+    this.canvas.addEventListener('wheel', this.boundInteractionHandlers.wheel, { passive: true });
   }
 
   private removeInteractionInvalidation(): void {

--- a/packages/gui/src/component.ts
+++ b/packages/gui/src/component.ts
@@ -18,6 +18,7 @@ export type BlockBuilder = () => Block;
 
 /** A render function is either a GUIControlBuilder or a BlockBuilder. */
 export type RenderFunction = GUIControlBuilder | BlockBuilder;
+export type RenderMode = 'continuous' | 'onDemand' | 'auto';
 
 export interface VitrineComponentConfig {
   /** Width in CSS pixels. If omitted, auto-sized from content. */
@@ -28,6 +29,10 @@ export interface VitrineComponentConfig {
   theme?: ThemeDefinition;
   /** Device pixel ratio override. */
   pixelRatio?: number;
+  /** Render scheduling strategy. Defaults to continuous for backward compatibility. */
+  renderMode?: RenderMode;
+  /** Whether pointer/wheel interactions should invalidate in non-continuous modes. Defaults to true. */
+  invalidateOnInteraction?: boolean;
   /** Additional renderer config overrides. */
   rendererConfig?: Partial<RendererConfig>;
 }
@@ -42,6 +47,18 @@ export class VitrineComponent {
   private theme: ThemeDefinition;
   private mounted: boolean = false;
   private mode: 'gui' | 'block';
+  private renderMode: RenderMode;
+  private invalidateOnInteraction: boolean;
+  private activeAnimationCount: number = 0;
+  private fDirty: boolean = false;
+  private boundInteractionHandlers: {
+    pointerdown: () => void;
+    pointerup: () => void;
+    pointermove: () => void;
+    click: () => void;
+    pointerleave: () => void;
+    wheel: () => void;
+  };
 
   constructor(
     renderFn: RenderFunction,
@@ -52,6 +69,16 @@ export class VitrineComponent {
     this.config = config;
     this.theme = config.theme ?? lightTheme;
     this.mode = mode;
+    this.renderMode = config.renderMode ?? 'continuous';
+    this.invalidateOnInteraction = config.invalidateOnInteraction ?? true;
+    this.boundInteractionHandlers = {
+      pointerdown: this.handleInteractionInvalidate.bind(this),
+      pointerup: this.handleInteractionInvalidate.bind(this),
+      pointermove: this.handleInteractionInvalidate.bind(this),
+      click: this.handleInteractionInvalidate.bind(this),
+      pointerleave: this.handleInteractionInvalidate.bind(this),
+      wheel: this.handleInteractionInvalidate.bind(this)
+    };
   }
 
   /** Create a component that renders GUI controls (high-level DSL). */
@@ -86,7 +113,8 @@ export class VitrineComponent {
     });
 
     this.mounted = true;
-    this.startRenderLoop();
+    this.setupInteractionInvalidation();
+    this.invalidate();
   }
 
   /** Unmount the component, stopping the render loop and cleaning up. */
@@ -94,6 +122,9 @@ export class VitrineComponent {
     if (!this.mounted) return;
 
     this.stopRenderLoop();
+    this.removeInteractionInvalidation();
+    this.fDirty = false;
+    this.activeAnimationCount = 0;
 
     if (this.renderer) {
       this.renderer.destroy();
@@ -112,11 +143,13 @@ export class VitrineComponent {
   /** Update the render function. Takes effect on the next frame. */
   setRenderFunction(renderFn: RenderFunction): void {
     this.renderFn = renderFn;
+    this.invalidate();
   }
 
   /** Update the theme. Takes effect on the next frame. */
   setTheme(theme: ThemeDefinition): void {
     this.theme = theme;
+    this.invalidate();
   }
 
   /** Resize the component. */
@@ -126,6 +159,7 @@ export class VitrineComponent {
     if (this.renderer) {
       this.renderer.resize(width, height);
     }
+    this.invalidate();
   }
 
   /** Returns the underlying canvas element, or null if not mounted. */
@@ -136,6 +170,44 @@ export class VitrineComponent {
   /** Returns true if the component is currently mounted. */
   isMounted(): boolean {
     return this.mounted;
+  }
+
+  /**
+   * Marks the component as dirty and schedules rendering based on renderMode.
+   * Call this after external state changes in onDemand/auto modes.
+   */
+  invalidate(): void {
+    this.fDirty = true;
+    this.scheduleNextFrame();
+  }
+
+  /** Change render mode at runtime. */
+  setRenderMode(renderMode: RenderMode): void {
+    this.renderMode = renderMode;
+    this.invalidate();
+  }
+
+  /** Get current render mode. */
+  getRenderMode(): RenderMode {
+    return this.renderMode;
+  }
+
+  /**
+   * Signals that an animation has started.
+   * In auto mode, this enables continuous RAF until endAnimation() balances it.
+   */
+  beginAnimation(): void {
+    this.activeAnimationCount += 1;
+    this.invalidate();
+  }
+
+  /**
+   * Signals that an animation has ended.
+   * The count is clamped at zero to keep state robust across mismatched calls.
+   */
+  endAnimation(): void {
+    this.activeAnimationCount = Math.max(0, this.activeAnimationCount - 1);
+    this.invalidate();
   }
 
   private resolveSize(): { width: number; height: number } {
@@ -160,16 +232,62 @@ export class VitrineComponent {
     };
   }
 
-  private startRenderLoop(): void {
-    const loop = (): void => {
-      if (!this.mounted || !this.renderer) return;
+  private shouldRunContinuously(): boolean {
+    if (this.renderMode === 'continuous') {
+      return true;
+    }
+    if (this.renderMode === 'auto') {
+      return this.activeAnimationCount > 0;
+    }
+    return false;
+  }
 
+  private scheduleNextFrame(): void {
+    if (!this.mounted || this.animationFrameId !== 0) return;
+    this.animationFrameId = requestAnimationFrame(this.onAnimationFrame);
+  }
+
+  private onAnimationFrame = (): void => {
+    this.animationFrameId = 0;
+    if (!this.mounted || !this.renderer) return;
+
+    const fContinuous = this.shouldRunContinuously();
+    const fShouldRender = fContinuous || this.fDirty;
+    if (fShouldRender) {
+      this.fDirty = false;
       const block = this.buildBlock();
       this.renderer.render(block);
-      this.animationFrameId = requestAnimationFrame(loop);
-    };
+    }
 
-    this.animationFrameId = requestAnimationFrame(loop);
+    if (this.shouldRunContinuously() || this.fDirty) {
+      this.scheduleNextFrame();
+    }
+  };
+
+  private setupInteractionInvalidation(): void {
+    if (!this.canvas) return;
+    this.canvas.addEventListener('pointerdown', this.boundInteractionHandlers.pointerdown);
+    this.canvas.addEventListener('pointerup', this.boundInteractionHandlers.pointerup);
+    this.canvas.addEventListener('pointermove', this.boundInteractionHandlers.pointermove);
+    this.canvas.addEventListener('click', this.boundInteractionHandlers.click);
+    this.canvas.addEventListener('pointerleave', this.boundInteractionHandlers.pointerleave);
+    this.canvas.addEventListener('wheel', this.boundInteractionHandlers.wheel);
+  }
+
+  private removeInteractionInvalidation(): void {
+    if (!this.canvas) return;
+    this.canvas.removeEventListener('pointerdown', this.boundInteractionHandlers.pointerdown);
+    this.canvas.removeEventListener('pointerup', this.boundInteractionHandlers.pointerup);
+    this.canvas.removeEventListener('pointermove', this.boundInteractionHandlers.pointermove);
+    this.canvas.removeEventListener('click', this.boundInteractionHandlers.click);
+    this.canvas.removeEventListener('pointerleave', this.boundInteractionHandlers.pointerleave);
+    this.canvas.removeEventListener('wheel', this.boundInteractionHandlers.wheel);
+  }
+
+  private handleInteractionInvalidate(): void {
+    if (!this.invalidateOnInteraction) return;
+    if (this.renderMode === 'continuous') return;
+    this.invalidate();
   }
 
   private stopRenderLoop(): void {

--- a/packages/gui/src/index.ts
+++ b/packages/gui/src/index.ts
@@ -67,4 +67,4 @@ export {
 
 // Component system
 export { VitrineComponent } from './component.ts';
-export type { VitrineComponentConfig, GUIControlBuilder, BlockBuilder, RenderFunction } from './component.ts';
+export type { VitrineComponentConfig, GUIControlBuilder, BlockBuilder, RenderFunction, RenderMode } from './component.ts';


### PR DESCRIPTION
## Summary
- add configurable render scheduling on VitrineComponent via renderMode (continuous, onDemand, auto)
- add invalidate(), beginAnimation(), endAnimation(), setRenderMode(), and getRenderMode()
- wire invalidation to mutators (setRenderFunction, setTheme, resize) and interaction events in non-continuous modes
- export RenderMode and update Block DSL docs

## Why
This reduces idle CPU usage for non-animated scenes by avoiding unconditional RAF in onDemand/auto modes while preserving backward-compatible default behavior.

## Validation
- pnpm build
- pnpm lint